### PR TITLE
Revert my reversion of chore: update hash domain to match core

### DIFF
--- a/chk-sig/src/lib.rs
+++ b/chk-sig/src/lib.rs
@@ -34,10 +34,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // This line needs to match with the Domain separator in the Tari Wallet
 // https://github.com/tari-project/tari/blob/development/base_layer/wallet/src/wallet.rs#L106-L110
-hash_domain!(
-    WalletMessageSigningDomain,
-    "com.tari.tari_project.base_layer.wallet.message_signing"
-);
+hash_domain!(WalletMessageSigningDomain, "com.tari.base_layer.wallet.message_signing");
 
 /// The version of this library
 #[wasm_bindgen]


### PR DESCRIPTION
This reverts commit f366cd09d6104638aa1b721898efe53435658252.

I pre-emptively merged this hash update. So then I reverted it. This PR reverts my revert to once again update the hash domain.